### PR TITLE
Important fixes 

### DIFF
--- a/Foundation/Assets/Foundation/Ioc/Injector.cs
+++ b/Foundation/Assets/Foundation/Ioc/Injector.cs
@@ -541,8 +541,8 @@ namespace Foundation
             var fields = instance.GetType().GetRuntimeFields().Where(o => o.HasAttribute<ImportAttribute>()).ToArray();
             var props = instance.GetType().GetRuntimeProperties().Where(o => o.HasAttribute<ImportAttribute>()).ToArray();
 #else
-            var fields = instance.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public).Where(o => o.HasAttribute<ImportAttribute>()).ToArray();
-            var props = instance.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public).Where(o => o.HasAttribute<ImportAttribute>()).ToArray();
+            var fields = instance.GetType().GetFields(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(o => o.HasAttribute<ImportAttribute>()).ToArray();
+            var props = instance.GetType().GetProperties(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic).Where(o => o.HasAttribute<ImportAttribute>()).ToArray();
 #endif
             for (int i = 0;i < fields.Length;i++)
             {

--- a/Foundation/Assets/Foundation/Ioc/InjectorInitialized.cs
+++ b/Foundation/Assets/Foundation/Ioc/InjectorInitialized.cs
@@ -5,6 +5,7 @@
 //  Published		: 2015
 //  -------------------------------------
 using System;
+using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 using UnityEngine;
@@ -194,7 +195,23 @@ namespace Foundation
         /// </summary>
         public static Type[] GetServiceTypes()
         {
-            return AppDomain.CurrentDomain.GetAssemblies().SelectMany(a => a.GetTypes().Where(o => o.HasAttribute<InjectorInitialized>())).ToArray();
+            var t = new List<Type>();
+
+            foreach (Assembly assembly in AppDomain.CurrentDomain.GetAssemblies())
+            {
+                try
+                {
+                    foreach (Type type in assembly.GetTypes())
+                        if (type.HasAttribute<InjectorInitialized>())
+                            t.Add(type);
+                }
+                catch
+                {
+                    Debug.LogError("Can't access assembly " + assembly.GetName());
+                }
+            }
+
+            return t.ToArray();
         }
 
         /// <summary>


### PR DESCRIPTION
## InjectorInitialized.cs:

After project build, the Injector began throw some exceptions when trying export some MonoBehaviour (Injector.AddExport(this))  

Well, after add try/catch between GetAssemblies, i found the error:

> "Can't load modules of assembly Newtonsoft.Json"

This is the Json.Net plugin, funny that this error don't appear in the editor
## Injector.cs:

Injection to NonPublic fields/properties to Subscribe too.

I forgot this on previous pull request.
